### PR TITLE
Fix:私有组件前缀改为__

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ src
   - pages
     - index
       - components
-        _common
+        __common
           header.vue
           footer.vue
         layout.vue
         _page.vue
 ```
 
-默认自动注册 `components` 目录所有组件, 其中不会注册 `_`开头的文件或者文件夹
+默认自动注册 `components` 目录所有组件, 其中不会注册 `__`开头的文件或者文件夹
 
 ```
 # src/pages/index/components/index.js

--- a/register-component.js
+++ b/register-component.js
@@ -18,7 +18,7 @@ async function resolveComponents(dir) {
   if (!fs.existsSync(dir)) {
     return
   }
-  return (await globby(['**/*.vue', '!**/_*.vue', '!_*/*.vue'], { cwd: dir }))
+  return (await globby(['**/*.vue', '!**/__*.vue', '!__*/*.vue'], { cwd: dir }))
 }
 
 class registerComponent {


### PR DESCRIPTION
私有组件前缀`_`改为`__`，兼容`vue cli generator`